### PR TITLE
Add period after the French word in the comment section

### DIFF
--- a/FLLex.txt
+++ b/FLLex.txt
@@ -24,7 +24,7 @@
 ˌɑ l ˈiː s i ɑ m , a l i z $alise. Gaulish (Savignac, Lambert, Delamarre). Rey 52.
 ˈɑ l l i oː s , o $aulx. Popeset. 
 ˈɑ l l i u m , a j $ail. Popeset.
-ˌɑ l k ˈuː n̪ ɑ m , o k y n̪ $aucune
+ˌɑ l k ˈuː n̪ ɑ m , o k y n̪ $aucune.
 ˌɑ l k ˈuː n̪ u m , o k œ̃ $aucun. Popeset. 
 ˌɑ l t̪ ˈɑ n̪ t̪ u m , o t̪ ɑ̃ $autant. Popeset. 
 ˈɑ l t̪ e r u m , o t̪ ʁ $autre. Popeset.
@@ -33,27 +33,27 @@
 ˈɑ k s e m , ɛ $ais. Popeset.
 ˌɑ k s ˈi l l ɑ m , ɛ s ɛ l $aisselle. Popeset. 
 ˈɑ k w ɑ m , o $eau. Popeset. 
-ˈɑ k w ɑː s , o $eaux
+ˈɑ k w ɑː s , o $eaux.
 ˌɑ k w ˈɑː r i u m , e v j e $évier. Popeset. 
-ˈɑ k w i l ɑ m , ɑ j $ > aille, obsolet̪e, but includ̪ed for purposes of test̪ing handling of intervocalic -kw-
+ˈɑ k w i l ɑ m , ɑ j $ > aille. obsolet̪e, but includ̪ed for purposes of test̪ing handling of intervocalic -kw-
 ˈɑ l n̪ u m , o n̪ $aune. Popeset. From Frankish int̪o Vulgar Latin-- Rey p154
 ˌɑ m ˈɑː r ɑ m , a m ɛ ʁ $amère. Popeset. 
 ˌɑ m ˈɑː r u m , a m ɛ ʁ $amer. Popeset.
 ˈɑ m ɑ t̪ , ɛ m $aime. Verb conjugation. Popeset. 
-ˌɑ m ˈiː k ɑ m , a m i $amie
+ˌɑ m ˈiː k ɑ m , a m i $amie.
 ˌɑ m ˈiː k ɑː s , a m i $amies.
 ˌɑ m ˈiː k oː s , a m i $amis. Popeset.
 ˌɑ m ˈiː k u m , a m i $ami. Popeset. 
 ˌɑ m ˌiː k i t̪ ˈɑː t̪ e m , a m i t̪ j e $amitié. Popeset.
-ˈɑ m p l u m , ɑ̃ p l $ample
-ˌɑ m p ˈu l l ɑ m , ɑ̃ p u l $ampoule
+ˈɑ m p l u m , ɑ̃ p l $ample.
+ˌɑ m p ˈu l l ɑ m , ɑ̃ p u l $ampoule.
 ˈɑ n̪ ɑ t̪ e m , a n̪ $ane. Popeset. Obsolete, but used to test timing of syllable falls relative to nasalization
 ˌɑ n̪ d̪ eː k ˈɑː n̪ eː s , ɑ̃ ʒ ɛ ʁ $Angers. Gaulish. Popeset.
 ˌɑ n̪ d̪ eː k ˈɑː w u m , ɑ̃ ʒ u $Anjou. Gaulish. 
 ˌɑ n̪ ˈe l l u m , a n̪ o $anneau. Popeset. 
 ˈɑ n̪ ɡ u l u m , ɑ̃ ɡ l $angle. Popeset.
 ˌɑ n̪ ɡ ˈu s t̪ i ɑ m , ɑ̃ ɡ w a s $angoisse. Popeset.
-ˌɑ n̪ ɡ ˌu s t̪ i ˈoː s u m , ɑ̃ ɡ w a s ø $angoisseux, dated. Popeset. 
+ˌɑ n̪ ɡ ˌu s t̪ i ˈoː s u m , ɑ̃ ɡ w a s ø $angoisseux. dated. Popeset. 
 ˌɑ n̪ i m ɑ m , o m $aume. obsolete. Replaced by clergical âme. Popeset. 
 ˌɑ n̪ i m ˈɑː l i ɑ , o m ɑ j $aumaille. Popeset. Pope says it is a loan s643, but̪ Rey d̪isagrees p154
 ˈɑ n̪ k o r ɑ m , ɑ̃ k ʁ $ancre. Popeset. 
@@ -67,10 +67,10 @@
 ˈɑː r e ɑ m , ɛ ʁ $aire. Popeset.
 ˌɑ r e w ˈe r n̪ i ɑ m , o v ɛ ʁ ɲ $Auvergne. Gaulish.
 ˌɑ r ɡ ˈe n̪ t̪ u m , a ʁ ʒ ɑ̃ $argent. Popeset. Possibly Gaulish.
-ˌɑ r k ˈɑː r i ɑ m , a ʁ ʃ ɛ ʁ $archère
+ˌɑ r k ˈɑː r i ɑ m , a ʁ ʃ ɛ ʁ $archère.
 ˌɑ r k ˈɑː r i u m , a ʁ ʃ e $archer. Popeset.
 ˈɑ r k ɑ m , a ʁ ʃ $arche. Popeset.
-ˌɑ r k ˈe l l u m , a ʁ s o $arceau
+ˌɑ r k ˈe l l u m , a ʁ s o $arceau.
 ˌɑ r k i ˈoː n̪ e m , a ʁ s ɔ̃ $arçon. Popeset. 
 ˈɑ r k uː m , a ʁ k $arc. Popeset. 
 ˌɑ r m ɑː t̪ ˈuː r ɑ m , a ʁ m y ʁ $armure. Popeset. 
@@ -84,7 +84,7 @@
 ˌɑ w ɡ ˈu s t̪ u m , u t̪ $août. Popeset.
 ˌɑ w i k ˈe l l oː s , w a z o $oiseaux. Popeset. 
 ˌɑ w i k ˈe l l u m , w a z o $oiseau. Popeset.
-ˌɑ w i ˈoː l ɑ m , a j œ l $aieule
+ˌɑ w i ˈoː l ɑ m , a j œ l $aieule.
 ˌɑ w i ˈoː l u m , a j œ l $aieul (ailleul?). Popeset. possible case of analogy from feminine form?
 ˌɑ w r ˈi k u l ɑ m , ɔ ʁ ɛ j $oreille. Popeset. 
 ˈɑ w r u m , ɔ ʁ $or. Popeset. 
@@ -154,7 +154,7 @@ b ˈu l ɡ ɑ m , b u ʒ $ bouge. Gaulish.
 b ˌu l l i ˈe n̪ t̪ e m , b u j ɑ̃ $bouillant. Popeset. Unknown non-Latin origin. Both Gaulish and Germanic are likely possibilities. 
 b ˈu n̪ d̪ ɑ m , b ɔ̃ d̪ $ bonde. Gaulish. Popeset. 
 b ˈu r ɡ u m , b u ʁ $ bourg. Germanic or Greek ultimate origin. Popeset. 
-b ˌu r r i ˈoː n̪ e m , b u ʁ ʒ ɔ̃ $bourgeon
+b ˌu r r i ˈoː n̪ e m , b u ʁ ʒ ɔ̃ $bourgeon.
 b ˈu t̪ i n̪ ɑ m , b ɔ ʁ n̪ $borne. Gaulish. Popeset. According to Rey, word in Standard French became bone, but was then replaced by borne, under unclear circumstances. Rey says borne is a dialect loan from Picard -- see Rey 275. However Pope is not so sure-- Pope s372, s378.
 
 d̪ ˈɑː m u m , d̪ ɛ̃ $ daim. Popeset. modern daim spelling would seem to be etymological as the word was dain in Old French (POpe page 624). Gaulish in origin.
@@ -368,7 +368,7 @@ i l l oː s , l e $les. Popeset.
 ˈi l l oː s , ø $eux. Popeset.
 i l l ˈuː i , l ɥ i $lui. Popeset.
 i l l u m , l ə $le. Popeset.
-ˌi m p e r ɑː t̪ ˈoː r e m , ɑ̃ p ʁ œ ʁ $empereur . Popeset. 
+ˌi m p e r ɑː t̪ ˈoː r e m , ɑ̃ p ʁ œ ʁ $empereur. Popeset. 
 ˌi n̪ , ɑ̃ $en. Popeset. 
 ˌi n̪ d̪ e , ɑ̃ $en. Popeset. effected by syntax, Pope s610.
 ˌi n̪ f ˈe r n̪ u m , ɑ̃ f ɛ ʁ $enfer. Popeset. 
@@ -390,8 +390,8 @@ i ˌu n̪ ˈiː k i ɑ , ʒ e n̪ i s $génisse. Popeset. Correct ancestral form
 i ˈuː n̪ i u m , ʒ ɥ ɛ̃ $juin. Popeset.
 i ˈuː s , ʒ y $jus. Popeset. 
 i ˈu w e n̪ e m , ʒ œ n̪ $jeune. Popeset.
-i ˌu w e n̪ k ˈe l l ɑ m , ʒ u v ɑ̃ s ɛ l $jouvencelle
-i ˌu w e n̪ k ˈe l l u m , ʒ u v ɑ̃ s o $jouvenceau
+i ˌu w e n̪ k ˈe l l ɑ m , ʒ u v ɑ̃ s ɛ l $jouvencelle.
+i ˌu w e n̪ k ˈe l l u m , ʒ u v ɑ̃ s o $jouvenceau.
 
 k ˌɑ b ˈɑ l l i k ˈɑː r e , ʃ ə v o ʃ e $ chevaucher. Gaulish. Verb. Popeset.
 k ˌɑ b ˈɑ l l i k ɑ t̪ , ʃ ə v o ʃ $ chevauche. Gaulish. Verb. Popeset.
@@ -402,7 +402,7 @@ k ˈa e̯ k u m , s j ø $cieu. largely obselete. Popeset.
 k ˈa e̯ l u m , s j ɛ l $ciel. Popeset. 
 k ˈa e̯ l oː s , s j ø $cieux. Popeset. Later effected by analogy from ciel singular. Pope 808, 814. But this does not seem to interfere with regular derivation
 k ˌa e̯ r e f ˈo l i u m , s ɛ ʁ f œ j $cerfeuil. Popeset. 
-k ˌɑ k i d̪ ˈoː s u m , ʃ a s j ø $chassieux as per Rey p443. Popeset.
+k ˌɑ k i d̪ ˈoː s u m , ʃ a s j ø $chassieux. as per Rey p443. Popeset.
 k ˌɑ k k ˈiː t̪ ɑ m , ʃ a s i $chassie. added for testing purposes about intervocalic geminate palatalization -- Rey p443. Form corrected as per TLFi: http://www.cnrtl.fr/definition/chassie
 k ˌɑ l ˈeː r e , ʃ a l w a ʁ $chaloir. Verb. Popeset. 
 k ˈɑ l i d̪ u m , ʃ o $chaud. Popeset. 
@@ -410,7 +410,7 @@ k ˈɑ l i d̪ ɑ m , ʃ o d̪ $chaude.
 k ˈɑ l k s , ʃ o $chaux. Popeset.
 k ˌɑ l ˈoː r e m , ʃ a l œ ʁ $chaleur. Popeset. 
 k ˈɑ l w ɑ m , ʃ o v $chauve. Popeset. 
-k ˌɑ m ˈe l l u m , ʃ a m o $chameau
+k ˌɑ m ˈe l l u m , ʃ a m o $chameau.
 k ˈɑ m e r ɑ m , ʃ ɑ̃ b ʁ $chambre. Popeset.
 k ˌɑ m ˈiː s i ɑ m , ʃ ə m i z $chemise. Popeset. Gaulish. 
 k ˌɑ m ˈiː n̪ u m , ʃ ə m ɛ̃ $chemin. Popeset. Gaulish.
@@ -423,11 +423,11 @@ k ˈɑ n̪ ɑ m , ʃ j ɛ n̪ $chienne. Popeset.
 k ˈɑ n̪ e m , ʃ j ɛ̃ $chien. Popeset.
 k ˌɑ n̪ d̪ e l ˈoː r u m , ʃ ɑ̃ d̪ ə l œ ʁ $chandeleur. Popeset. 
 k ˌɑː n̪ ˈuː t̪ u m , ʃ ə n̪ y $chenu. Popeset. 
-k ˌɑː n̪ ˈuː t̪ ɑ m , ʃ ə n̪ y $chenue 
+k ˌɑː n̪ ˈuː t̪ ɑ m , ʃ ə n̪ y $chenue.
 k ˌɑ p ˈi l l u m , ʃ ə v ø $cheveu. Popeset. later affected by analogy -- Pope s759... but doesn't seem to interfere with regular processes
 k ˌɑ p ˈi l l oː s , ʃ ə v ø $cheveux. Popeset. 
 k ˈɑ p p ɑ m , ʃ a p $chappe. Popeset. 
-k ˌɑ p p ˈe l l ɑ m , ʃ a p ɛ l $chapelle
+k ˌɑ p p ˈe l l ɑ m , ʃ a p ɛ l $chapelle.
 k ˌɑ p p ˈe l l u m , ʃ a p o $chapeau. Popeset. 
 k ˈɑ p r ɑ m , ʃ ɛ v ʁ $chèvre. Popeset. 
 k ˌɑ p t̪ i ˈɑː r e , ʃ a s e $chasser. Verb. Popeset. 
@@ -455,7 +455,7 @@ k ˈɑ t̪ t̪ u m , ʃ a $chat.
 k ˈɑ t̪ʰ e d̪ r ɑ m , ʃ ɛ z $chaise. Popeset. Affected by irregular buzzing (chaire>chaise)
 k ˌɑ w ˈɑ n̪ n̪ u m , ʃ w ɑ̃ $chouan. Popeset. Gaulish- Pope s6. 
 k ˌɑ w e ˈo l ɑ , ʒ o l $geôle. Popeset. Pope seems to consider this regular. However, she does not explain the stress on a short penultimate o, why that o did not become œ despite being open, or the voicing of the initial k to ɡ before palatalization
-k ˌɑː w ˈi k u l ɑ m , ʃ ə v i j $cheville? From Rey p458.
+k ˌɑː w ˈi k u l ɑ m , ʃ ə v i j $cheville. From Rey p458.
 k ˈɑ w l i s , ʃ u $chou. Popeset.
 k ˈɑ w s ɑ m , ʃ o z $chose. Popeset.
 k ˈe n̪ t̪ u m , s ɑ̃ $cent. Popeset.
@@ -495,7 +495,7 @@ k ˌo l ˈu m b ɑ , k o l ɔ̃ b $colombe. Popeset. Affected by "Latin influenc
 k ˈo k k u m , k ɔ k $coq. Popeset. Ultimate origin uncertain-- could be Gaulish ('red' -- however coccus was widely found in ex-Roman area beyond Celtic regions, i.e. Albanian kuq), another good candidate is Frankish may have to remove.
 k ˌo kʰ l e ˈɑː r i u m , k ɥ i j ɛ ʁ $cuillère. Popeset.
 k ˈo k s ɑ , k ɥ i s $ cuisse. Popeset.
-k ˈo k w u s , k ø $queux, dated. Popeset. 
+k ˈo k w u s , k ø $queux. dated. Popeset. 
 k ˈo m i t̪ e m , k ɔ̃ t̪ $comte. Popeset.
 k ˌo m m e ˈɑː t̪ u m , k ɔ̃ ʒ e $congé. Popeset. 
 k ˌo m m ˈuː n̪ e m , k ɔ m œ̃ $commun. Popeset. 
@@ -513,13 +513,13 @@ k ˈo r i u m , k ɥ i ʁ $cuir. Popeset.
 k ˌo r ˈoː n̪ ɑ m , k u ʁ ɔ n̪ $couronne. Popeset.
 k ˈo r p u s , k ɔ ʁ $corps. From the nominative. Popeset. 
 k ˌo r r ˈi ɡ i ɑ , k u ʁ w a $courroie. Popeset. 
-k ˌo r r o ɡ ˈɑː t̪ ɑ m , k ɔ ʁ v e $to corvée as per Pope s341. Popeset.
-k ˈo s t̪ ɑ m , k o t̪ $co^te not in Pope. As per Rey.
+k ˌo r r o ɡ ˈɑː t̪ ɑ m , k ɔ ʁ v e $corvée. as per Pope s341. Popeset.
+k ˈo s t̪ ɑ m , k o t̪ $côte. not in Pope. As per Rey.
 k ˌo s t̪ ˈɑː t̪ u m , k o t̪ e $côté. not in Pope. Rey p572. For testing purposes.
 k r ˈɑ s s ɑ m , ɡ ʁ ɑ s $grasse. Popeset.
 k r ˈɑ s s ɑː s , ɡ ʁ ɑ s $grasses.
-k r ˈɑ s s i ɑ , ɡ ʁ ɛ s $graisse, form as per Rey 1022. Popeset.
-k r ˈɑ s s oː s , ɡ ʁ ɑ $gras
+k r ˈɑ s s i ɑ , ɡ ʁ ɛ s $graisse. form as per Rey 1022. Popeset.
+k r ˈɑ s s oː s , ɡ ʁ ɑ $gras.
 k r ˈɑ s s u m , ɡ ʁ ɑ $gras. Popeset.
 k r ˌɑː t̪ ˈiː k u l ɑ , ɡ ʁ i j $ grille. Popeset. Form as per Pope s243.
 k r ˈeː d̪ i s , k ʁ w a $crois. Popeset.
@@ -527,7 +527,7 @@ k r ˌeː s k ˈe n̪ t̪ e m , k ʁ w a s ɑ̃ $croissant. Popeset.
 k r ˈeː t̪ ɑ m , k ʁ ɛ $craie. Popeset.
 k r ˈuː d̪ ɑ m , k ʁ y $crue. 
 k r ˈuː d̪ ɑː s , k ʁ y $crues. 
-k r ˈuː d̪ oː s , k ʁ y $crus
+k r ˈuː d̪ oː s , k ʁ y $crus.
 k r ˈuː d̪ u m , k ʁ y $cru. Popeset.
 k r ˈu k e m , k ʁ w a $croix. Popeset. 
 k r ˈu s t̪ ɑ m , k ʁ u t̪ $croûte. 
@@ -555,16 +555,16 @@ k w ˈɑ t̪ t̪ u o r , k a t̪ ʁ $quatre. Popeset.
 k w ˌɑ t̪ t̪ u ˈo r d̪ e k i m , k a t̪ ɔ ʁ z $quatorze. Popeset.
 k w e m , k ə $que. Popeset.
 k ˌe r k ˈe d̪ u l ɑ m , s a ʁ s ɛ l $sarcelle. Popeset. Inherited form as kerkedula and not kwerkwedula per Andre' via TLFi: https://www.cnrtl.fr/definition/sarcelle 
-k w ˈiː , k i $qui stressed. Popeset. As per Pope 863.
-k w ˌiː , k i $qui unstressed. Popeset. As per Pope 863.
-k w ˈi d̪ , k w a $quoi, quid stressed. Popeset. As per Pope 863.
+k w ˈiː , k i $qui. stressed. Popeset. As per Pope 863.
+k w ˌiː , k i $qui. unstressed. Popeset. As per Pope 863.
+k w ˈi d̪ , k w a $quoi. quid stressed. Popeset. As per Pope 863.
 k w i ˈeː t̪ u m , k w a $coi. Popeset. No countertonic in Latin as per Pope s216.
 k w ˈiː n̪ d̪ e k i m , k ɛ̃ z $quinze. Popeset. 
 k w ˈiː n̪ k w e , s ɛ̃ k $cinq. Popeset. Possibly effected by lexical pressures, along with 6,7,9 and 10. Remove all if so.
 k w ˈiː n̪ k w ɑː ɡ ˈi n̪ t̪ ɑ m , s ɛ̃ k ɑ̃ t̪ $cinquante. Popeset. Pope s 662 has quinquanta, but elsewhere she explains how -aginta became anta. However Rey says it is from Latin quinquaginta.
 k w ˌiː n̪ t̪ ˈɑː n̪ ɑ m , k ɛ̃ t̪ ɛ n̪ $quintaine. Rey 1931.
-k w ˈiː n̪ t̪ u m , k ɛ̃ $quint, dated. Popeset. 
-k w ˌi d̪ , k ə $que, quid unstressed. Popeset. As per Pope 863.
+k w ˈiː n̪ t̪ u m , k ɛ̃ $quint. dated. Popeset. 
+k w ˌi d̪ , k ə $que. quid unstressed. Popeset. As per Pope 863.
 k w ˈoː m o d̪ o , k ɔ m $comme. Popeset.
 
 l ˈɑ b r ɑ m , l ɛ v ʁ $lèvre. Popeset. 
@@ -574,7 +574,7 @@ l ˈɑ k r i m ɑ m , l a ʁ m $larme. Popeset.
 l ˌɑ k s ˈɑː r e , l ɛ s e $laisser. Popeset. Verb. As per Pope  was regularly derived to laissier until Middle French analogy to -sser from other verbs -- Pope 877. But we have found this can actually be derived regularly.
 l ˈɑ k t̪ e m , l ɛ $lait. Popeset. 
 l ˌɑ k t̪ ˈuː k ɑ m , l ɛ t̪ y $laitue. Popeset.
-l ˈɑ k w e u m , l a $lacs i.e. noose. Popeset. As per Pope 187.
+l ˈɑ k w e u m , l a $lacs. i.e. noose. Popeset. As per Pope 187.
 l ˈɑ m i n̪ ɑ m , l a m $lame. Popeset.
 l ˈɑ m p ɑ d̪ ɑ , l ɑ̃ p $lampe. Popeset. Latin form as per Pope 354.
 l ˌɑ m p r ˈeː d̪ ɑ m , l ɑ̃ p ʁ w a $lamproie. Popeset. Gaulish. 
@@ -582,8 +582,8 @@ l ˈɑː n̪ ɑ m , l ɛ n̪ $laine.
 l ˈɑ n̪ d̪ ɑ m , l ɑ̃ d̪ $lande. Gaulish. landa.
 l ˈɑ n̪ e ɑ , l ɑ̃ ʒ $lange. Popeset. As per Pope s203. 
 l ˈɑ n̪ k e ɑ m , l ɑ̃ s $lance. From Gaulish. lankia.
-l ˌɑ n̪ t̪ ˈe r n̪ ɑ m , l ɑ̃ t̪ ɛ ʁ n̪ $lanterne
-l ˈɑː r i d̪ u m , l a ʁ $lard 
+l ˌɑ n̪ t̪ ˈe r n̪ ɑ m , l ɑ̃ t̪ ɛ ʁ n̪ $lanterne.
+l ˈɑː r i d̪ u m , l a ʁ $lard.
 l ˈɑ s s ɑ m , l ɑ s $lasse. Popeset.
 l ˈɑ s s u m , l ɑ $las. Popeset. 
 l ˈɑ t̪ i ɑ m , l ɛ z $laize. as per Rey 1236 : LAIZE.
@@ -599,14 +599,14 @@ l ˌeː ɡ ˈɑː l e m , l w a j a l $loyal. Popeset.
 l ˌeː ɡ ˈɑː l eː s , l w a j o $loyaux.
 l ˈeː ɡ e m , l w a $loi. Popeset.
 l ˈe k t̪ u m , l i $lit. Popeset.
-l ˈe n̪ d̪ i t̪ e m , l ɑ̃ t̪  $lente
-l ˈe n̪ t̪ ɑ m , l ɑ̃ t̪ $lente
-l ˈe n̪ t̪ u m , l ɑ̃ $lent
+l ˈe n̪ d̪ i t̪ e m , l ɑ̃ t̪  $lente.
+l ˈe n̪ t̪ ɑ m , l ɑ̃ t̪ $lente.
+l ˈe n̪ t̪ u m , l ɑ̃ $lent.
 l ˌe p o r ˈɑː r i u m , l e v ʁ i j e $levrier. Popeset.
 l ˈe p o r e m , l j ɛ v ʁ $lièvre. Popeset. Origin unknown -- perhaps Iberian of some sort. 
-l ˈe s s u m , l ɛ $lais singular, as per Rey 1235, under LAISSER
+l ˈe s s u m , l ɛ $lais. singular, as per Rey 1235, under LAISSER
 l ˈe u k ɑ m , l j ø $lieue. Gaulish. Popeset. leuca. Affected by metathesis in Gallo-Roman leuga>legwa as per Pope s328.
-l ˌe w ˈɑː m e n̪ , l ə v ɛ̃ $levain
+l ˌe w ˈɑː m e n̪ , l ə v ɛ̃ $levain.
 l ˌiː b ˈe l l u m , n̪ i v o $niveau. unexplained l>n initial mutation strikes again. But this is inherited -- Rey 1499.
 l ˈiː b r ɑ m , l i v ʁ $livre. Popeset. 
 l ˈiː ɡ ɑ m , l i $lie. Gaulish. Popeset. 
@@ -657,7 +657,7 @@ m ˈɑ n̪ i k ɑ m , m ɑ̃ ʃ $manche. Popeset. Considered regular by Pope (s3
 m ˌɑ n̪ s i ˈoː n̪ e m , m ɛ z ɔ̃ $maison. Popeset. 
 m ˌɑː n̪ s u eː t̪ ˈiː n̪ u m , m ɑ t̪ ɛ̃ $ma^tin. Popeset. 
 m ˌɑ n̪ s ˈuː r ɑ m , m a z y ʁ $masure.
-m ˌɑ n̪ t̪ ˈe l l u m , m ɑ̃ t̪ o $manteau
+m ˌɑ n̪ t̪ ˈe l l u m , m ɑ̃ t̪ o $manteau.
 m ˈɑ n̪ u m , m ɛ̃ $main. Popeset. 
 m ˌɑ n̪ uː ˈo p e r ɑ , m a n̪ œ v ʁ $manœuvre. As per Rey 1337, itˌs from a contraction of manu opera but the contraction was formed already in Popular Latin.
 m ˈɑ n̪ uː s , m ɛ̃ $mains. Popeset. As per Pope.
@@ -678,12 +678,12 @@ m ˌɑ t̪ r ˈɑ s t̪ r ɑ , m a ʁ ɑ t̪ ʁ $marâtre. Popeset.
 m ˈɑ t̪ r e m , m ɛ ʁ $mère. Popeset.
 m ˈɑ t̪ t̪ e ɑ m , m a s $masse. Popeset.
 m ˈɑ t̪ t̪ e ˈuː k ɑ m , m a s y $massue. Popeset. 
-m ˌɑː t̪ ˈuː r ɑ m , m y ʁ $mûre
+m ˌɑː t̪ ˈuː r ɑ m , m y ʁ $mûre.
 m ˌɑː t̪ ˈuː r u m , m y ʁ $mûr. Popeset.
 m ˌɑː t̪ uː t̪ ˈiː n̪ u m , m a t̪ ɛ̃ $matin. Popeset.
 m e ˌɑ m , m a $ma. As per Pope s855. Popeset.
-m e ɑː s , m e $mes feminine. Pope s855. Popeset. 
-m e oː s , m e $mes masculine. Pope s855. Popeset. 
+m e ɑː s , m e $mes. feminine. Pope s855. Popeset. 
+m e oː s , m e $mes. masculine. Pope s855. Popeset. 
 m ˈeː , m w a $moi. Popeset.
 m ˈe u m , m j ɛ̃ $mien. Popeset. Archaic, but included in both Pope and Rey. Pope s855.
 m e ˌu m , m ɔ̃ $mon. Popeset. As per Pope s855.
@@ -691,7 +691,7 @@ m ˌe d̪ ˈɑː l i ɑ , m ɑ j $maille. Popeset. See Rey 1319. Modern pronunci
 m ˌe d̪ i ˈɑː n̪ ɑ m , m w a j ɛ n̪ $moyenne. Popeset.
 m ˌe d̪ i ˈɑː n̪ u m , m w a j ɛ̃ $moyen. Popeset.
 m ˌe d̪ i e t̪ ˈɑː t̪ e m , m w a t̪ j e $moitié. Popeset. "Réfection" as per Rey however (Rey 1427-1428).
-m ˈe d̪ i u m , m i $mi . Popeset. 
+m ˈe d̪ i u m , m i $mi. Popeset. 
 m ˌe d̪ ˈu l l ɑ m , m w a l $moelle. Popeset. Case of metathesis -- Rey 1425.
 m ˈe l , m j ɛ l $miel. Popeset. 
 m ˌe l i ˈoː r e m , m ɛ j œ ʁ $meilleur. Popeset.
@@ -716,7 +716,7 @@ m ˌi n̪ ˈɑː r i , m ə n̪ e $mener. Verb. Popeset.
 m ˈi n̪ o r , m w ɛ̃ d̪ ʁ $moindre. Popeset. from nominative as per Rey 146.
 m ˈi n̪ u s , m w ɛ̃ $moins. 
 m ˌi n̪ uː t̪ i ˈɑː r e , m ɛ̃ s e $mincer. Popeset. Verb. 
-m ˌi s k u l ˈɑː r e , m ɛ l e $mêler
+m ˌi s k u l ˈɑː r e , m ɛ l e $mêler.
 m ˈi s s ɑ m , m ɛ s $messe. Popeset. 
 m ˈi s s u m , m ɛ $mets. Popeset. The orthographic t, orthographic only, is likely the result of folk etymology.
 m ˈoː b i l e m , m œ b l $meuble. Popeset. as per Rey the long o became short via contamination from movere in Vulgar Latin (Rey 1401)-- but Pope treats it as regular.
@@ -731,12 +731,12 @@ m ˌo l l i ˈɑː r e , m u j e $mouiller.
 m ˌo n̪ ˈeː t̪ ɑ m , m ɔ n̪ ɛ $monnaie. Popeset. Effected by "irregular" lower class urban shift of wɛ>ɛ, see Pope s522, may have to remove.
 m ˌo n̪ t̪ ˈɑː n̪ e ɑ m , m ɔ̃ t̪ a ɲ $montagne. Popeset.
 m ˈo n̪ t̪ e m , m ɔ̃ $mont. Popeset.
-m ˌo n̪ t̪ i k ˈe l l u m , m ɔ̃ s o $monceau
+m ˌo n̪ t̪ i k ˈe l l u m , m ɔ̃ s o $monceau.
 m ˈoː r eː s , m œ ʁ $mœurs.
 m ˌo r ˈiː r i , m u ʁ i ʁ $mourir. Verb. Popeset. 
 m ˈo r d̪ e r e , m ɔ ʁ d̪ ʁ $mordre. Verb. Popeset. 
 m ˈo r s u m , m ɔ ʁ $mors.
-m ˌo r t̪ ˈɑː r i u m , m ɔ ʁ t̪ j e $mortier
+m ˌo r t̪ ˈɑː r i u m , m ɔ ʁ t̪ j e $mortier.
 m ˈo r t̪ e m , m ɔ ʁ $mort. Popeset. 
 m ˈo w i t̪ ɑ m , m ø t̪ $meute. Popeset.
 m ˈu f f u l ɑ m , m u f l $moufle. Possibly Frankish., see Rey 1450.
@@ -753,12 +753,12 @@ m ˈu t̪ t̪ u m , m o $mot. Popeset.
 
 n̪ ˈɑ w d̪ ɑ m , n̪ u $noue. Gaulish. 
 n̪ ˈɑː n̪ ɑ m , n̪ ɛ n̪ $naine. 
-n̪ ˈɑː n̪ u m , n̪ ɛ̃ $nain
+n̪ ˈɑː n̪ u m , n̪ ɛ̃ $nain.
 n̪ ˈɑː s k e r e , n̪ ɛ t̪ ʁ $naître. Popeset. 
-n̪ ˈɑ s s ɑ m , n̪ ɑ s $nasse
+n̪ ˈɑ s s ɑ m , n̪ ɑ s $nasse.
 n̪ ˈɑː s u m , n̪ e $nez. Popeset.
 n̪ ˌɑː t̪ ˈɑː l e m , n̪ ɔ ɛ l $Noël. Popeset. A > o in first syllable par dissimilation (Rey 1502)
-n̪ ˌɑː t̪ ˈiː w ɑ m , n̪ a i v $naïve
+n̪ ˌɑː t̪ ˈiː w ɑ m , n̪ a i v $naïve.
 n̪ ˌɑː t̪ ˈiː w u m , n̪ a i f $naïf. Popeset. 
 n̪ ˈɑː w e m , n̪ ɛ f $nef. Popeset. 
 n̪ ˈɑ w i k ɑ m , n̪ u $noue. 
@@ -768,7 +768,7 @@ n̪ ˈe k , n̪ i $ni. Popeset. seems that some hold this from just nec, others 
 n̪ ˌe p ˈoː t̪ e m , n̪ ə v ø $neveu. Popeset. 
 n̪ ˈe p t̪ i ɑ m , n̪ j ɛ s $nièce. Popeset.
 n̪ ˌe p t̪ ˈuː n̪ u m , l y t̪ ɛ̃ $lutin. Popeset. How this happened is... mysterious. See Pope s517.
-n̪ ˈe r w u m , n̪ ɛ ʁ f $nerf
+n̪ ˈe r w u m , n̪ ɛ ʁ f $nerf.
 n̪ ˈiː d̪ u m , n̪ i $nid. Popeset. 
 n̪ ˈi ɡ r u m , n̪ w a ʁ $noir. Popeset. 
 n̪ ˈi t̪ i d̪ ɑ m , n̪ ɛ t̪ $nette. Popeset. 
@@ -780,26 +780,26 @@ n̪ ˈo k t̪ e m , n̪ ɥ i $nuit. Popeset.
 n̪ ˈoː m e n̪ , n̪ ɔ̃ $nom. Popeset.
 n̪ ˈoː n̪ , n̪ ɔ̃ $non. Popeset.
 n̪ oː n̪ , n̪ ə $ne. Popeset. Unstressed development as per Pope s699.
-n̪ ˌoː n̪ ɑː ɡ ˈi n̪ t̪ ɑ , n̪ o n̪ ɑ̃ t̪ $nonante, dated. Popeset.  
+n̪ ˌoː n̪ ɑː ɡ ˈi n̪ t̪ ɑ , n̪ o n̪ ɑ̃ t̪ $nonante. dated. Popeset.  
 n̪ ˈo n̪ n̪ ɑ m , n̪ ɔ n̪ $nonne. Popeset.
 n̪ ˈo p t̪ i ɑ m , n̪ ɔ s $noce. Popeset. this is noptiae in Rey 1501-- but result is the same.
 n̪ ˌoː s , n̪ u $nous. Pope s827-828. Popeset. Only secondarily stressed version inherited it is thought -- s827.
 n̪ ˈo s t̪ r ɑ m , n̪ ɔ t̪ ʁ $notre. Popeset.
 n̪ ˈo s t̪ r u m , n̪ ɔ t̪ ʁ $notre. Popeset. 
-n̪ ˌo w ˈe l l ɑ m , n̪ u v ɛ l $nouvelle
+n̪ ˌo w ˈe l l ɑ m , n̪ u v ɛ l $nouvelle.
 n̪ ˌo w ˈe l l u m , n̪ u v o $nouveau. Popeset. 
 n̪ ˈo w e m , n̪ œ f $neuf. Popeset. 
 n̪ ˈuː b ɑ m , n̪ y $nue. Popeset. 
 n̪ ˈuː d̪ ɑ m , n̪ y $nue. Popeset. 
-n̪ ˈuː d̪ u m , n̪ y $nu . Popeset. 
+n̪ ˈuː d̪ u m , n̪ y $nu. Popeset. 
 n̪ ˈu k e m , n̪ w a $noix. Popeset. Pope attributes (s670) to nucem but Rey holds it is from the plural nuces (Rey 1503). Pope gives an alternate pronunciation as n̪wɑ, but doesnˌt explain this.
-n̪ ˈuː l l ɑ m , n̪ y l $nulle
-n̪ ˈuː l l ɑː s , n̪ y l $nulles
+n̪ ˈuː l l ɑ m , n̪ y l $nulle.
+n̪ ˈuː l l ɑː s , n̪ y l $nulles.
 n̪ ˈuː l l oː s , n̪ y $nuls. Popeset. 
 n̪ ˈuː l l u m , n̪ y l $nul. Popeset.
 n̪ ˈu m e r u m , n̪ ɔ̃ b ʁ $nombre. Popeset.
 n̪ ˌu t̪ r ˈiː k i ɑ , n̪ u ʁ i s $nourrice. Popeset. From neuter plural. Some sources hold that the original u was long but Pope holds that the root had short u (see nutritura -- s257); note that other Romance reflexes like in Spanish for hte etymon also developed as if it is was a short u.
-n̪ ˌu t̪ r ˈiː t̪ i ˈoː n̪ e m , n̪ u ʁ i s ɔ̃ $nourrisson 
+n̪ ˌu t̪ r ˈiː t̪ i ˈoː n̪ e m , n̪ u ʁ i s ɔ̃ $nourrisson.
 
 ˌo s s i f r ˈɑː ɡ ɑ m , ɔ ʁ f ʁ ɛ $orfraie. Popeset. 
 ˈo s t̪ r e ɑ , ɥ i t̪ ʁ $huître. Popeset. Latin form as per Pope 313.
@@ -826,15 +826,15 @@ p ˈɑ l m ɑ m , p o m $paume. Popeset.
 p ˌɑ l p ˈe t̪ r ɑ m , p o p j ɛ ʁ $paupiere. Popeset.
 p ˈɑː n̪ e m , p ɛ̃ $pain. Popeset.
 p ˌɑː n̪ ˈɑː r i u m , p a n̪ j e $panier. Popeset. Pope seems to imply in the index it is Frankish. but this may be a typo. Rey and most other sources hold it to come from Latin panarium.
-p ˌɑ n̪ n̪ ˈe l l u m , p a n̪ o $panneau
-p ˈɑ n̪ n̪ u m , p ɑ̃ $pan
-p ˈɑ n̪ t̪ i k e m , p ɑ̃ s $panse
+p ˌɑ n̪ n̪ ˈe l l u m , p a n̪ o $panneau.
+p ˈɑ n̪ n̪ u m , p ɑ̃ $pan.
+p ˈɑ n̪ t̪ i k e m , p ɑ̃ s $panse.
 p ˌɑː p i l i ˈoː n̪ e m , p a v i j ɔ̃ $pavillon. Popeset.
 p ˈɑː r , p ɛ ʁ $pair. 
 p ˌɑ r ˈɑ b o l ɑ m , p a ʁ ɔ l $parole. Popeset.
 p ˌɑ r ɑ w e r ˈeː d̪ u m , p a l ə f ʁ w a $palefroi. Popeset. This is obviously highly irregular. It is from multiple non-Latin sources : para < Greek and veredus is Gaulish. According to Rey the word is from the Balkans, and it entered French through Germanic... which would lead to its exclusion here; however we are going with Pope's implication that it is regular and continuously developed in her table.
 p ˈɑ r e m , p ɛ ʁ $pair. Popeset. 
-p ˌɑ r ˈe n̪ t̪ e m , p a ʁ ɑ̃ $parent
+p ˌɑ r ˈe n̪ t̪ e m , p a ʁ ɑ̃ $parent.
 p ˌɑ r e n̪ t̪ ˈɑː t̪ u m , p a ʁ ɑ̃ t̪ e $parenté. Popeset.
 p ˈɑ r i ɑ , p ɛ ʁ $paire. Popeset.
 p ˌɑ r i ˈeː t̪ e m , p a ʁ w a $paroi. Popeset. See Pope 222
@@ -847,7 +847,7 @@ p ˌɑ r t̪ i k ˈe l l ɑ m , p a ʁ s ɛ l $parcelle. Popeset.
 p ˈɑ s s u m , p ɑ $pas.
 p ˈɑ s t̪ ɑ m , p ɑ t̪ $pâte. Popeset. Late Latin, loan from Greek.
 p ˈɑː s t̪ o r , p ɑ t̪ ʁ $pâtre. Popeset. From nominative-vocative as per Pope 806, not accusative pa:sto:rem
-p ˌɑ t̪ ˈe l l ɑ m , p w a l $poêle from patella. Popeset. Development is unexpected but treated as regular by Pope: Pope s241, 720. Also, Rey 1779.
+p ˌɑ t̪ ˈe l l ɑ m , p w a l $poêle. from patella. Popeset. Development is unexpected but treated as regular by Pope: Pope s241, 720. Also, Rey 1779.
 p ˌɑ t̪ r ˈɑ s t̪ r u m , p a ʁ ɑ t̪ ʁ $parâtre. Popeset.
 p ˈɑ t̪ r e m , p ɛ ʁ $père. Popeset. 
 p ˌɑ t̪ r ˈiː n̪ u m , p a ʁ ɛ̃ $parrain.
@@ -871,7 +871,7 @@ p ˈe l l e m , p o $peau. Popeset.
 p ˈe l l eː s , p o $peaux. Popeset.
 p ˈe n̪ d̪ i t̪ ɑ m , p ɑ̃ t̪ $pente.
 p ˌeː n̪ i k ˈe l l u m , p ɛ̃ s o $pinceau. Popeset. See Rey s1738
-p ˈeː n̪ s i l e m , p w a l $poêle from pe:nsilem. Popeset. 
+p ˈeː n̪ s i l e m , p w a l $poêle. from pe:nsilem. Popeset. 
 p ˈeː n̪ s u m , p w a $poids. Popeset. Spelling is effected by folk etymology, but not pronunciation. Rey 1781.
 p ˌe r , p a ʁ $par. Popeset.
 p ˌe r d̪ ˈiː k e m , p ɛ ʁ d̪ ʁ i $perdrix. Popeset. Irregular development detailed on Rey 1683 and Pope 126.
@@ -882,10 +882,10 @@ p ˌe r ˈiː k u l u m , p e ʁ i l $péril. Popeset. possible that modern pron
 p ˈe r k ɑ m , p ɛ ʁ ʃ $perche. From Greek into Late Latin.
 p ˈe r n̪ u l ɑ m , p ɛ ʁ l $perle.
 p ˌe r p e t̪ ˈɑː n̪ e u m , p a ʁ p ɛ̃ $parpaing. Rey
-p ˈe r s ɑ m , p ɛ ʁ s $perse
+p ˈe r s ɑ m , p ɛ ʁ s $perse.
 p ˈe r s i k ɑ m , p ɛ ʃ $pêche. Popeset. 
 p ˌe r s ˈoː n̪ ɑ m , p ɛ ʁ s ɔ n̪ $personne. Popeset, form as per s665. 
-p ˈe r s u m , p ɛ ʁ $pers
+p ˈe r s u m , p ɛ ʁ $pers.
 p ˈe r t̪ i k ɑ m , p ɛ ʁ ʃ $perche. Popeset. 
 p ˌe r t̪ uː s i ˈɑː r e , p ɛ ʁ s e $percer. Popeset. Verb.
 p ˌe r t̪ ˈuː s i u m , p ɛ ʁ t̪ ɥ i $pertuis. Popeset. Inherited as per Pope 315. Rey disagrees, says it is a mere deverbalization -- Rey 1697-1698
@@ -894,7 +894,7 @@ p ˈe s s i m u m , p ɛ m $pême. Popeset. Now archaic.
 p ˈe t̪ r ɑ m , p j ɛ ʁ $pierre. Popeset.
 p ˈe t̪ r u m , p j ɛ ʁ $Pierre.
 p ˈe t̪ t̪ i ɑ m , p j ɛ s $pièce. Popeset. Gaulish per Blazhek, also Rey p1725.
-p ˈiː ɑ m , p i $pie
+p ˈiː ɑ m , p i $pie.
 p ˌi e t̪ ˈɑː t̪ e m , p i t̪ j e $pitié. Popeset. Regular as per Pope. In the first syllable, ie>ij and then the jt somehow blocked lenition, it seems. Pope 227,316,510,588,666
 p ˌi ɡ r ˈi t̪ i ɑ m , p a ʁ ɛ s $paresse. Popeset
 p ˈiː l ɑ m , p i l $pile.
@@ -907,7 +907,7 @@ p ˌi k t̪ o r ˈiː n̪ ɑ m , p w a t̪ ʁ i n̪ $poitrine. Rey 1788.
 p ˌiː n̪ k i ˈoː n̪ e m , p ɛ̃ s ɔ̃ $pinson. Gaulish in origin.
 p ˈi n̪ k t̪ o r , p ɛ̃ t̪ ʁ $peintre. Popeset. From nominative as per Pope 806. Rey disagrees and says it is from accusative pinctorem -- however he is probably wrong as this would regularly render peinteur /pɛ̃tœʁ/ not pɛ̃tʁ.
 p ˈi n̪ n̪ ɑ m , p a n̪ $panne. Popeset.
-p ˈiː n̪ u m , p ɛ̃ $pin
+p ˈiː n̪ u m , p ɛ̃ $pin.
 p ˈi p e r ɑ , p w a v ʁ $poivre. Popeset. Note, "emprunt" (loan) as per Rey 1788-1789. Others disagree: (Deroy, Lˌemprunt linguistique) : https://books.openedition.org/pulg/681: "est herite du latin piper". Rey may have referred to it being loaned from Persian to Latin?
 p ˌiː p i ˈoː n̪ e m , p i ʒ ɔ̃ $pigeon. Popeset.
 p ˈi r ɑ m , p w a ʁ $poire. Popeset. See Pope 774 -- from neuter plural.
@@ -1003,7 +1003,7 @@ p ˈu n̪ k t̪ ɑ m , p w ɛ̃ t̪ $pointe. Rey 1782.
 p ˌu n̪ k t̪ i ˈoː n̪ e m , p w ɛ̃ s ɔ̃ $poinçon. Rey 1782. Not in Pope.
 p ˈu n̪ k t̪ u m , p w ɛ̃ $point. Popeset.
 p ˌu n̪ k t̪ ˈuː r ɑ m , p w ɛ̃ t̪ y ʁ $pointure. Popeset.
-p ˈuː r ɑ m , p y ʁ $pure
+p ˈuː r ɑ m , p y ʁ $pure.
 p ˌuː r ɡ ˈɑː r e , p y ʁ ʒ e $purger. Verb. Popeset. 
 p ˈuː r u m , p y ʁ $pur. Popeset. 
 p ˈu r p p u r ɑ m , p u ʁ p ʁ $pourpre. Popeset. Ultimate origin is Greek. Gemination of p due to Greek origin as per Pope s629
@@ -1015,7 +1015,7 @@ r ˌɑ d̪ iː k ˈiː n̪ ɑ m , ʁ a s i n̪ $racine. Popeset.
 r ˈɑ d̪ i u m , ʁ ɛ $rai. Popeset. 
 r ˌɑ k ˈeː m u m , ʁ ɛ z ɛ̃ $raisin. Popeset.
 r ˌɑ m ˈe l l u m , ʁ a m o $rameau.
-r ˈɑː n̪ ɑ m , ʁ ɛ n̪ $raine, dated. Popeset.
+r ˈɑː n̪ ɑ m , ʁ ɛ n̪ $raine. dated. Popeset.
 r ˌɑ n̪ k ˈoː r e m , ʁ ɑ̃ k œ ʁ $rancœur. Popeset.
 r ˈɑ p i d̪ u m , ʁ a d̪ $rade. Popeset. See Pope 231 for any questions
 r ˌɑ s k u l ˈɑː r e , ʁ ɑ l e $râler. Verb. Rey 1950-1951. Not in Pope.
@@ -1024,7 +1024,7 @@ r ˌɑ t̪ i ˈoː n̪ e m , ʁ ɛ z ɔ̃ $raison. Rey 1949, not in Pope.
 r ˈɑː s u m , ʁ e $rez. Popeset. Dated
 r ˌe d̪ ˌe m p t̪ i ˈoː n̪ e m , ʁ ɑ̃ s ɔ̃ $rançon. Per Rey 1955. Not in Pope.
 r ˌeː ɡ ˈɑː l e m , ʁ w a j a l $royal. Popeset.
-r ˌeː ɡ ˈɑː l eː s , ʁ w a j o $royaux
+r ˌeː ɡ ˈɑː l eː s , ʁ w a j o $royaux.
 r ˈeː ɡ e m , ʁ w a $roi. Popeset.
 r ˈe m , ʁ j ɛ̃ $rien. Popeset.
 r ˈe n̪ d̪ i t̪ ɑ m , ʁ ɑ̃ t̪ $rente.
@@ -1038,8 +1038,8 @@ r ˈi k ɑ m , ʁ ɛ $raie. Popeset. Gaulish in origin. Riga in Rey, but fixed p
 r ˈi ɡ i d̪ ɑ m , ʁ ɛ d̪ $raide. Popeset. 
 r ˈiː p ɑ m , ʁ i v $rive. Popeset.
 r ˌiː p ˈɑː r i ɑ m , ʁ i v j ɛ ʁ $riviere. Not in Pope. Rey 2069.
-r ˈiː s u m , ʁ i $ris, dated. Popeset. Per Pope s206. Note, however, Rey calls this a loan ("emprunt" -- page 2066).
-r ˌoː b ˈiː k u l ɑ m , ʁ u j $rouille From Rey 2105. Not in Pope.
+r ˈiː s u m , ʁ i $ris. dated. Popeset. Per Pope s206. Note, however, Rey calls this a loan ("emprunt" -- page 2066).
+r ˌoː b ˈiː k u l ɑ m , ʁ u j $rouille. From Rey 2105. Not in Pope.
 r ˈo k k ɑ m , ʁ o ʃ $roche. Popeset. Likely Gaulish in origin (or Brythonic if coming from Breton rocˌh )
 r ˈoː t̪ u n̪ u m , ʁ o n̪ $ Rhône. Popeset. Gaulish in origin. Latin spelling was Rhodanum, currently using Gaulish Rotunon. Might need to exclude as it does not run through the Francien region. 
 r ˈu b e u m , ʁ u ʒ $rouge. Popeset.
@@ -1088,14 +1088,14 @@ s ˈɑ p ɑ m , s ɛ v $seve. Popeset.
 s ˌɑ p ˈɑ w d̪ i ɑ m , s a v w a $Savoie. From Gaulish.
 s ˌɑ p ˈeː r e , s a v w a ʁ $savoir. Popeset. Verb.
 s ˈɑ p i ɑ m , s a ʃ $sache. Verb conjugation. Popeset.
-s ˈɑ p i d̪ u m , s a d̪ $sade, dated. Popeset.
+s ˈɑ p i d̪ u m , s a d̪ $sade. dated. Popeset.
 s ˌɑ p i ˈe n̪ t̪ e m , s a v ɑ̃ $savant. Popeset. As per Pope 220.
 s ˌɑː p ˈoː n̪ e m , s a v ɔ̃ $savon. Popeset. From Germanic of some sort.
 s ˌɑ p ˈoː r e m , s a v œ ʁ $saveur. Rey 2161. Not in Pope.
 s ˌɑ p p ˈiː n̪ u m , s a p ɛ̃ $sapin. Blend of Gaulish sappos (fir) and Latin pi:nus (pine).
 s ˌɑ r m ˈe n̪ t̪ u m , s a ʁ m ɑ̃ $sarment. Not in Pope. Rey 2150.
 s ˌɑ t̪ i ˈoː n̪ e m , s ɛ z ɔ̃ $saison. Popeset.
-s ˌɑ t̪ ˈu l l u m , s u $saoûl, soûl. Popeset. For Rey (p2280) this is a refection.
+s ˌɑ t̪ ˈu l l u m , s u $saoûl. also soûl. Popeset. For Rey (p2280) this is a refection.
 s ˌɑ w k ˈoː n̪ ɑ m , s o n̪ $Saône. Popeset. From Gaulish Saukonna, the river goddess. Pope gives Saukona-- I have my doubts about this form but listed Popeˌs version.
 s ˈeː , s w a $soi. Popeset.
 s ˌe d̪ ˈeː r e , s w a ʁ $seoir. Verb. Popeset. 
@@ -1140,7 +1140,7 @@ s ˌi n̪ ɡ u l ˈɑː r e m , s ɑ̃ ɡ l i e $sanglier. Popeset. Pope 665.
 s ˈiː n̪ u m , s ɛ̃ $sein. Popeset.
 s ˌi t̪ ˈe l l u m , s o $seau. Popeset. Gender shift from sitella.
 s k ˌi n̪ t̪ ˈi l l ɑ , e t̪ ɛ̃ s ɛ l $étincelle. Popeset. Victim of metathesis per Rey 835.
-s k ˈo r t̪ e ɑ , e k ɔ ʁ s $écorce
+s k ˈo r t̪ e ɑ , e k ɔ ʁ s $écorce.
 s k ˌuː t̪ ˈɑː r i u m , e k ɥ i j e $écuyer. Popeset.
 s k ˌuː t̪ ˈe l l ɑ , e k ɥ ɛ l $écuelle. Popeset. 
 s ˌo l i d̪ ˈɑː r e , s u d̪ e $souder. Verb. Popeset. 
@@ -1162,13 +1162,13 @@ s p ˈo n̪ s u m , e p u $époux.
 s p ˈi s s ɑ m , e p ɛ s $épaisse. Popeset.
 s p ˈi s s u m , e p ɛ $épais. Popeset.
 s t̪ ˈɑ ɡ n̪ u m , e t̪ ɛ̃ $étain. Rey attributes it to Gaulish. Rey 829. Unclear if from stagnum or stannum. Much more likely stagnum-- stannum would be irregular.
-s t̪ ˈɑː m e n̪ , e t̪ ɛ̃ $étaim 
-s t̪ ˈeː l ɑ m , e t̪ w a l $étoile
+s t̪ ˈɑː m e n̪ , e t̪ ɛ̃ $étaim.
+s t̪ ˈeː l ɑ m , e t̪ w a l $étoile.
 s t̪ r ˌɑ n̪ ɡ u l ˈɑː r e , e t̪ ʁ ɑ̃ ɡ l e $étrangler. Verb. Not in Pope. 
 s t̪ r ˈeː n̪ ɑ m , e t̪ ʁ ɛ n̪ $étrenne. Popeset. 
-s t̪ r ˈi k t̪ ɑ m , e t̪ ʁ w a t̪ $étroite
+s t̪ r ˈi k t̪ ɑ m , e t̪ ʁ w a t̪ $étroite.
 s t̪ r ˈi k t̪ u m , e t̪ ʁ w a $étroit. Popeset.
-s t̪ ˌu r n̪ ˈe l l u m , e t̪ u ʁ n̪ o $étourneau
+s t̪ ˌu r n̪ ˈe l l u m , e t̪ u ʁ n̪ o $étourneau.
 s ˈu ɑ , s ø $seue. Popeset. Dated. Pope s228,851,855,857,859.
 s u ˌɑ , s a $sa. Popeset. Third person possessive feminine.
 s u ˌɑː s , s ɛ $ses. Popeset. Pope 851,853,855
@@ -1189,7 +1189,7 @@ s ˌu p e r ˈɑː n̪ u m , s u v ʁ ɛ̃ $souverain. Popeset. But note, Rey ca
 s ˌu p e r k ˈi l i u m , s u ʁ s i $sourcil. Popeset. Note however Rey says it is a "refection" (Rey 2285)
 s ˈu p p ɑ m , s u p $soupe. Rey 2282-2283. Not in Pope.
 s ˈu r d̪ ɑ m , s u ʁ d̪ $sourde. Popeset. "Refection" for Rey (2284-2285)
-s ˈu r d̪ u m , s u ʁ $sourd (sourt) . Popeset. "Refection" for Rey (2284-2285).
+s ˈu r d̪ u m , s u ʁ $sourd. (sourt) . Popeset. "Refection" for Rey (2284-2285).
 s ˈuː r s u m , s y $sus. Popeset. Initial u long as per Pope 359.
 s ˌu s p e k t̪ i ˈoː n̪ e m , s u p s ɔ̃ $soupçon. Popeset.
 s u ˌu m , s ɔ̃ $son. Popeset. Pope 851,853,855,860.
@@ -1263,7 +1263,7 @@ t̪ ˈoː t̪ t̪ u m , t̪ u $tout.Popeset.  Pronounced with "emphatic geminate
 t̪ r ˈɑː d̪ i t̪ o r , t̪ ʁ ɛ t̪ ʁ $traitre. Popeset. From the nominative case traditor, not tradito:rem. Rey 2480-2481. The latter rendered traitour -- see Pope s725,800,806-- now obselete. Traitre does seem to behave irregularly though (unsure why it is not *trattre or traire) 
 t̪ r ˈɑ ɡ e r e , t̪ ʁ ɛ ʁ $traire. Verb. Popeset. 
 t̪ r ˌɑ k t̪ ˈɑː r e , t̪ ʁ ɛ t̪ e $traiter. Verb. Popeset. 
-t̪ r ˈɑ k t̪ u m , t̪ ʁ ɛ $Rey 2479. Not in Pope directly
+t̪ r ˈɑ k t̪ u m , t̪ ʁ ɛ $trait. Rey 2479. Not in Pope directly
 t̪ r ˈɑː n̪ s , t̪ ʁ ɛ $treˈs. Rey 2501. Not in Pope.
 t̪ r ˈɑ w k u m , t̪ ʁ u $trou. Gaulish in origin. Popeset. 
 t̪ r ˌe m u l ˈɑː r e , t̪ ʁ ɑ̃ b l e $trembler. Rey 2498. Popeset. 
@@ -1295,7 +1295,7 @@ t̪ u ˌu m , t̪ ɔ̃ $ton. Popeset. Pope s855.
 
 ˌu b iː , u $ouˈ. Popeset. 
 ˈu m b r ɑ m , ɔ̃ b ʁ $ombre. Popeset. 
-ˈu m k w ɑ m , ɔ̃ k $onc, onques.Popeset. 
+ˈu m k w ɑ m , ɔ̃ k $onques. (also onc). Popeset. 
 ˈuː n̪ ɑ m , y n̪ $une. Popeset. 
 ˈu n̪ d̪ ɑ m , ɔ̃ d̪ $onde. 
 ˈu n̪ d̪ e k i m , ɔ̃ z $onze. Popeset. 
@@ -1309,7 +1309,7 @@ t̪ u ˌu m , t̪ ɔ̃ $ton. Popeset. Pope s855.
 w ˌɑ l ˈe n̪ t̪ i ɑ m , v a l ɑ̃ s $valence.
 w ˌɑ l ˈeː r e , v a l w a ʁ $valoir. Verb. Popeset. 
 w ˈɑ l l e m , v a l $val. Popeset. 
-w ˈɑ l l eː s , v o $vaux
+w ˈɑ l l eː s , v o $vaux.
 w ˌɑ l ˈoː r e m , v a l œ ʁ $valeur.
 w ˈɑ k k ɑ m , v a ʃ $vache. Popeset.
 w ˈɑː n̪ ɑ m , v ɛ n̪ $vaine. Popeset. 
@@ -1326,7 +1326,7 @@ w ˌeː k ˈiː n̪ u m , v w a z ɛ̃ $voisin. Popeset. Mutation from Classical
 w ˈe k t̪ e m , v i $vit. Rey 2623. 
 w ˌe k t̪ ˈuː r ɑ m , v w a t̪ y ʁ $voiture. Popeset. 
 w ˈeː l ɑ m , v w a l $voile. Popeset. 
-w ˈe l t̪ r ɑ ɡ u m , v o t̪ ʁ $vautre (veautre). Popeset. Gaulish. 
+w ˈe l t̪ r ɑ ɡ u m , v o t̪ ʁ $vautre. (veautre). Popeset. Gaulish. 
 w ˌeː n̪ ɑː t̪ ˈoː r e m , v ə n̪ œ ʁ $veneur. Rey 2574. 
 w ˈe n̪ d̪ e r e , v ɑ̃ d̪ ʁ $vendre. Verb. Popeset. 
 w ˌe n̪ e r i s d̪ ˈiː e m , v ɑ̃ d̪ ʁ ə d̪ i $vendredi. Rey 2573.


### PR DESCRIPTION
This helps delimiting the French word, e.g. if the format was to evolve to something like CSV, e.g.
r ˌoː b ˈiː k u l ɑ m , ʁ u j $rouille From Rey 2105. Not in Pope. becomes
r ˌoː b ˈiː k u l ɑ m , ʁ u j $rouille. From Rey 2105. Not in Pope. The French word is then found between $ and . on any line of the dataset.